### PR TITLE
chore(npm): Change vue peer dependency to allow minor version changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "codegen": "mkdir -p ./src/lib/common/ && copyfiles -u 3 '../lib-common/src/**/*' './src/lib/common'"
   },
   "peerDependencies": {
-    "vue": "~3.4.30",
+    "vue": "^3.4.30",
     "@solana/web3.js": ">=1.54.0",
     "bs58": "^4.0.1",
     "tweetnacl": "^1.0.3"


### PR DESCRIPTION
This allows peer dependancies to run higher minor versions of vuejs. 

The latest version of vue has a bugfix that I need and this is preventing the update.

Thank you :) 